### PR TITLE
Remove unneeded path part

### DIFF
--- a/source/conf.js
+++ b/source/conf.js
@@ -66,7 +66,7 @@ conf = Object.assign({}, conf, {
   API_URL: url.format(parsedServerHttpUrl),
   HOST_NAME: parsedServerHttpUrl.hostname,
   PARSED_API_URL: parsedServerHttpUrl,
-  TEMPLATE_ROOT_NEW: modulesPath('@iml', 'gui', 'dist') + path.sep,
+  TEMPLATE_ROOT_NEW: modulesPath('@iml', 'gui') + path.sep,
   TEMPLATE_ROOT_OLD: modulesPath('@iml', 'old-gui', 'templates') + path.sep,
   HELP_TEXT: helpText
 });


### PR DESCRIPTION
When loading the gui template, we can just use @iml/gui. Index.html lives at the top level.