### PR TITLE
GH-15 Update path for TEMPLATE_ROOT_NEW.

### DIFF
--- a/source/conf.js
+++ b/source/conf.js
@@ -66,7 +66,8 @@ conf = Object.assign({}, conf, {
   API_URL: url.format(parsedServerHttpUrl),
   HOST_NAME: parsedServerHttpUrl.hostname,
   PARSED_API_URL: parsedServerHttpUrl,
-  TEMPLATE_ROOT_NEW: modulesPath('@iml', 'gui', 'dist') + path.sep,
+  TEMPLATE_ROOT_NEW:
+    path.sep + path.join('usr', 'lib', 'iml-manager', 'iml-gui') + path.sep,
   TEMPLATE_ROOT_OLD: modulesPath('@iml', 'old-gui', 'templates') + path.sep,
   HELP_TEXT: helpText
 });


### PR DESCRIPTION
Fixes #15.

GUI has been packaged into its own RPM. The path will now be under
/usr/lib/iml-manager/iml-gui. Update the path for TEMPLATE_ROOT_NEW.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>